### PR TITLE
Fix: Default to installed Webrix

### DIFF
--- a/webpack/webpack.constants.js
+++ b/webpack/webpack.constants.js
@@ -1,12 +1,15 @@
+const fs = require('fs');
 const path = require('path');
 const root = path.resolve(__dirname, '..');
+const webrixBuildPath = path.resolve(__dirname, '../../webrix/build/');
+const webrixInstalledPath = root + '/node_modules/webrix';
 
 const paths = {
     root,
     src: root + '/src',
     build: root + '/build',
     resources: root + '/src/resources',
-    webrix: path.resolve(__dirname, '../../webrix/build/'),
+    webrix: fs.existsSync(webrixBuildPath) ? webrixBuildPath : webrixInstalledPath,
     node_modules: root + '/node_modules',
 }
 


### PR DESCRIPTION
### Description:
Fixing #24 which is about using Webrix from node_modules if webrix/build does not exit locally.